### PR TITLE
Add Component Syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,6 +153,40 @@
             </td>
           </tr>
         </tbody>
+
+        <tbody id=components>
+          <tr>
+            <th rowspan=4>Components</th>
+            <td><code># Work Made For Hire</code></td>
+            <td class=commonform><h2>Work Made For Hire</h2></td>
+            <td rowspan=2>To reuse a contract component, write its URL in angle brackets.  To disable automatic upgrades, follow the URL with “without upgrades”.</td>
+          </tr>
+          <tr>
+            <td><code>&lt;https://commonform.org/kemitchell/work-made-for-hire-unless-employment/1e1c&gt;</code></td>
+            <td class=commonform>
+              <h3 id="component1heading1">Express Agreement to Make "Work Made for Hire"</h3>
+              <p>Subject to <a href="#component1heading2">State Employment Law Exception</a>, as far as the law allows, <em>Work</em> will be "work made for hire" under copyright law.</p>
+              <h3 id="component1heading2">State Employment Law Exception</h3>
+              <p><a href="#component1heading1">Express Agreement to Make Work Made for Hire</a> does not apply if it would make <em>Contractor</em> an employee for purposes of state employment law that applies to <em>Contractor</em>.</p>
+            </td>
+          </tr>
+          <tr>
+            <td><code># Term</code></td>
+            <td class=commonform><h2>Term</h2></td>
+            <td rowspan=2>To disable automatic upgrades, follow the URL with “without upgrades”. To specify term and heading replacements, write them in a list after the URL.</td>
+          </tr>
+          <tr>
+            <td><code>&lt;https://commonform.org/rxnda/term/1e&gt; without upgrades, replacing _Confidential Information_ with _Trade Secrets_, [Confidentiality Obligations](#Confidentiality_Obligations) with [Nondisclosure](#Nondisclosure)</code></td>
+            <td class=commonform>
+              <h3>Expiration</h3>
+              <p>Unless extended by signed, written agreement of the parties, this agreement will terminate automatically on the first anniversary of the date of this agreement.</p>
+              <h3>Termination by Notice</h3>
+              <p>Either party may terminate this agreement early by thirty calendar days’ prior written notice to the other party.</p>
+              <h3>Survival</h3>
+              <p>Obligations under <del><a href=#>Confidentiality Obligations</a></del><ins><a href=#>Nondisclosure</a></ins> survive the term of this agreement for <del><em>Confidential Information</em></del><ins><em>Trade Secrets</em></ins> disclosed during the term for five calendar years from the date of termination.</p>
+            </td>
+          </tr>
+        </tbody>
       </table>
       </section>
 


### PR DESCRIPTION
@compleatang and @anseljh: This PR adds a syntax for reusable contract components to type.commonform.org. I've quoted the examples from the patch below. I already have a parser for this syntax in [commonform-commonmark](https://github.com/commonform/commonform-commonmark). It should be even easier to stringify.

## Simple
```
# Work Made For Hire
<https://commonform.org/kemitchell/work-made-for-hire-unless-employment/1e1c>
```

## With Substitutions

```
# Term	
<https://commonform.org/rxnda/term/1e> without upgrades, replacing _Confidential Information_ with _Trade Secrets_, and [Confidentiality Obligations](#Confidentiality_Obligations) with [Nondisclosure](#Nondisclosure)
```